### PR TITLE
Array type fix

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -143,8 +143,15 @@ Needle.prototype.setup = function(uri, options) {
   }
 
   function check_value(expected, key) {
-    var value = get_option(key),
+    var type;
+    var value = get_option(key);
+
+    if (expected === 'array' && Array.isArray(value)) {
+        type = 'array';
+    }
+    else {
         type  = typeof value;
+    }
 
     if (type != 'undefined' && type != expected)
       throw new TypeError(type + ' received for ' + key + ', but expected a ' + expected);


### PR DESCRIPTION
Otherwise `typeof [1, 2, 4]` returns `object`. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FOperators%2Ftypeof
